### PR TITLE
ci(workflows): add workflow to notify parent repo on push

### DIFF
--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -1,0 +1,24 @@
+name: Notify Parent Repository
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  notify-parent:
+    name: Notify parent repository of submodule update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger parent repository workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PARENT_REPO_TOKEN }}
+          repository: Ahsan-Studio/traccar
+          event-type: submodule-update
+          client-payload: |
+            {
+              "submodule": "traccar-web",
+              "ref": "${{ github.ref }}",
+              "sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
Add GitHub Actions workflow to notify the parent repository when a push occurs on master. This allows the parent to react to submodule updates automatically.